### PR TITLE
Reconfigure GPIOs and enable PWM audio

### DIFF
--- a/software/src/i_main.c
+++ b/software/src/i_main.c
@@ -51,7 +51,7 @@ void D_DoomMain (void);
 #if PICO_ON_DEVICE
 #include "pico/binary_info.h"
 //dahai
-bi_decl(bi_3pins_with_names(PICO_AUDIO_I2S_DATA_PIN, "I2S DIN", PICO_AUDIO_I2S_CLOCK_PIN_BASE, "I2S BCK", PICO_AUDIO_I2S_CLOCK_PIN_BASE+1, "I2S LRCK"));
+bi_decl(bi_2pins_with_func(PICO_AUDIO_PWM_LEFT_PIN, PICO_AUDIO_PWM_RIGHT_PIN, GPIO_FUNC_PWM));
 #endif
 
 int main(int argc, char **argv)

--- a/software/src/i_video.h
+++ b/software/src/i_video.h
@@ -30,8 +30,8 @@
 #define SCREENHEIGHT 200
 #endif
 #ifdef ST7789
-#define SCREENWIDTH  320
-#define SCREENHEIGHT 200
+#define SCREENWIDTH  240
+#define SCREENHEIGHT 240
 #endif
 
 #if DOOM_TINY

--- a/software/src/pico/CMakeLists.txt
+++ b/software/src/pico/CMakeLists.txt
@@ -33,10 +33,7 @@ target_include_directories(common_pico INTERFACE
 
 target_compile_definitions(common_pico INTERFACE
         NO_USE_MOUSE=1
-        #dahai
-        PICO_AUDIO_I2S_PIO=1
-        PICO_AUDIO_I2S_DMA_IRQ=1
-        )
+)
 
 pico_generate_pio_header(common_pico ${CMAKE_CURRENT_LIST_DIR}/video_doom.pio)
 target_link_libraries(common_pico INTERFACE pico_stdlib pico_multicore pico_scanvideo_dpi)
@@ -52,13 +49,11 @@ endif()
 #dahai
 # disable scanvideo's pin
 target_compile_definitions(common_pico INTERFACE
-    PICO_SCANVIDEO_COLOR_PIN_BASE=30 
+    PICO_SCANVIDEO_COLOR_PIN_BASE=30
     PICO_SCANVIDEO_SYNC_PIN_BASE=30
-    PICO_AUDIO_I2S_DATA_PIN=7
-    PICO_AUDIO_I2S_CLOCK_PIN_BASE=30
 )
 
-target_link_libraries(common_pico INTERFACE hardware_spi)
+target_link_libraries(common_pico INTERFACE hardware_spi hardware_pwm pico_audio_pwm)
 
 set(SD_SPI "spi1" CACHE STRING "Specify the SPI bus for the SD card")
 set(SD_CS "13" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
@@ -70,12 +65,12 @@ set(SD_MISO "12" CACHE STRING "Select the Master In Slave Out GPIO pin for the S
 set(LCD_CONTROLLER "ST7789" CACHE STRING "Select the LCD controller type")
 
 set(LCD_SPI "spi0")
-set(LCD_DC "20")
-set(LCD_CS "17")
+set(LCD_DC "17")
+set(LCD_CS "21")
 set(LCD_CLK "18")
 set(LCD_MOSI "19")
-set(LCD_RST "21")
-set(LCD_BL "22")
+set(LCD_RST "20")
+set(LCD_BL "16")
 set(LCD_MISO "-1")
 
 message("SD card SPI         : ${SD_SPI}")
@@ -108,13 +103,12 @@ target_compile_definitions(common_pico INTERFACE
     DISPLAY_PIN_MISO=${LCD_MISO}
 )
 
-    #target_link_libraries(common_pico INTERFACE  hardware_pwm)
-    #target_link_libraries(common_pico INTERFACE  pico_audio_pwm)
 target_compile_definitions(common_pico INTERFACE
-        #PICO_AUDIO_PWM_PIO=7
-        #USE_CUSTOM_AUDIO_PWM=1
-        USE_AUDIO_I2S=1
-        #USE_AUDIO_PWM=1
+        USE_AUDIO_PWM=1
+        PICO_AUDIO_PWM_PIN_BASE=14
+        PICO_AUDIO_PWM_PIN_COUNT=2
+        PICO_AUDIO_PWM_LEFT_PIN=14
+        PICO_AUDIO_PWM_RIGHT_PIN=15
 )
 if(LCD_CONTROLLER STREQUAL "ILI9341")
     add_compile_definitions(ILI9341)

--- a/software/src/pico/i_input.c
+++ b/software/src/pico/i_input.c
@@ -521,14 +521,14 @@ static void pico_quit(void) {
 }
 #endif
 //dahai
-#define PIN_UP 9
-#define PIN_DN 5
-#define PIN_LT 8
-#define PIN_RT 6
-#define PIN_SL 28
-#define PIN_ST 4
-#define PIN_A 2
-#define PIN_B 3
+#define PIN_RT  2
+#define PIN_LT  3
+#define PIN_UP  4
+#define PIN_DN  5
+#define PIN_SL  6
+#define PIN_ST  7
+#define PIN_A   8
+#define PIN_B   9
 
 void magc_key_init(void) {
     gpio_deinit(PIN_UP);

--- a/software/src/pico/i_video.c
+++ b/software/src/pico/i_video.c
@@ -276,7 +276,7 @@ const scanvideo_mode_t vga_mode_320x200 =
                 .width = 320,
                 #endif
                 #ifdef ST7789
-                .width = 160,
+                .width = 240,
                 #endif
 #else
                 .width = 640,
@@ -289,10 +289,10 @@ const scanvideo_mode_t vga_mode_320x200 =
                 .yscale = 5,
                 #endif
                 #ifdef ST7789
-                .xscale = 2,
-                .yscale = 5,
+                .xscale = 1,
+                .yscale = 1,
 
-                .height = 200,
+                .height = 240,
                 #endif
                 // .xscale = 2,
                 // .yscale = 5,
@@ -1474,22 +1474,13 @@ void ili9341_infones_frame_timing_register_init()
 }
 void st7789_infones_frame_timing_register_init()
 {
-        uint8_t command;
-        uint8_t data[4];
-        int x=0;
+        display_set_address(0, 0, DISPLAY_WIDTH - 1, DISPLAY_HEIGHT - 1);
 
-
-
-        // display_set_address(0, 0, (SCREENWIDTH)/2, (MAIN_VIEWHEIGHT)/2);
-        display_set_address(0, 10, (SCREENWIDTH)/2, 96+3+10);
-
-////
         /*
          *   keep chip select active, let the next data be written continuously
          */
         gpio_put(DISPLAY_PIN_DC, 1);
         gpio_put(DISPLAY_PIN_CS, 0);
-
 }
 
 void I_InitGraphics(void)

--- a/software/src/pico/magc.h
+++ b/software/src/pico/magc.h
@@ -57,8 +57,8 @@ typedef WORD            WCHAR;  /* UTF-16 character type */
 #define    DISPLAY_HEIGHT 240
 #endif
 #ifdef ST7789
-#define    DISPLAY_WIDTH 160
-#define    DISPLAY_HEIGHT 128
+#define    DISPLAY_WIDTH 240
+#define    DISPLAY_HEIGHT 240
 #endif
 
 #undef    DISPLAY_INVERT 
@@ -68,13 +68,13 @@ const uint LED_PIN = PICO_DEFAULT_LED_PIN;
 /*
  *
  */
-#define UP 9
+#define UP 4
 #define DN 5
-#define LT 8
-#define RT 6
-#define SL 28
-#define ST 4
-#define A 2
-#define B 3
+#define LT 3
+#define RT 2
+#define SL 6
+#define ST 7
+#define A 8
+#define B 9
 
 #endif


### PR DESCRIPTION
## Summary
- map buttons to GPIO 2-9
- move LCD control pins and backlight to GPIO 16-21
- switch audio output to PWM on GPIO 14 and 15 and link PWM libraries

## Testing
- `cmake ..` *(fails: add_subdirectory given source "doom" which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5dce7acc83239ad04af644c0e6b5